### PR TITLE
Add custom websocket.Upgrader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ messages to all consumers of the channel. We do this by calling
 
 ```go
 type RoomChannel struct {
-	  tb *thunderbird.Thunderbird
+    tb *thunderbird.Thunderbird
 }
 
 func (rc *RoomChannel) Received(event thunderbird.Event) {
-	  switch event.Type {
-	  case "message":
-		  rc.tb.Broadcast(event.Channel, event.Body)
-	  }
+    switch event.Type {
+    case "message":
+      rc.tb.Broadcast(event.Channel, event.Body)
+    }
 }
 ```
 
@@ -134,6 +134,27 @@ do that with the `perform` method of the connection:
 ```js
 // when enter key is pressed
 conn.perform("room", msg)
+```
+
+### Client's host is different than server
+
+If client is hosted on another server than Thunderbird runs, most likely they have different hostnames.  
+In such a case, you should use `Thunderbird.HTTPHandlerWithUpgrader()` and define your custom Origin header validator.
+
+```go
+func main() {
+  tb := thunderbird.New()
+  tbUpgrader := websocket.Upgrader{
+    ReadBufferSize:  1024,
+    WriteBufferSize: 1024,
+    CheckOrigin: func(r *http.Request) bool {
+      return true
+    },
+  }
+
+  mux := http.NewServeMux()
+  mux.Handle("/ws", tb.HTTPHandlerWithUpgrader(tbUpgrader))
+}
 ```
 
 ## Roadmap

--- a/thunderbird.go
+++ b/thunderbird.go
@@ -62,6 +62,10 @@ func (tb *Thunderbird) HTTPHandler() http.Handler {
 	}
 }
 
+func (tb *Thunderbird) HTTPHandlerWithUpgrader(upgrader websocket.Upgrader) http.Handler {
+	return &httpHandler{tb: tb, upgrader: upgrader}
+}
+
 func (tb *Thunderbird) connected(c *Connection) {
 	tb.connMutex.Lock()
 	tb.connections[c] = true


### PR DESCRIPTION
I host client and server from different hostnames, in that case gorilla's [checkSameOrigin](https://github.com/gorilla/websocket/blob/master/server.go#L111) method runs and doesn't give access to client because Origin header doesn't match with hostname of server.

Basically I need a custom origin check method to run, so I've added a new method that takes websocket.Upgrader as a parameter to support custom upgrader with CheckOrigin function.

ps Thanks for thunderbird and keep up the good work :+1: 
